### PR TITLE
Use helmet to hide all the details and add security headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const express = require('express');
 const winston = require('winston');
 const expressWinston = require('express-winston');
 const bodyParser = require('body-parser')
+const helmet = require('helmet');
 const config = require('./lib/config');
 const {IncrementalsPlugin} = require('./IncrementalsPlugin.js');
 
@@ -28,6 +29,7 @@ const logger = winston.createLogger({
   exitOnError: false, // do not exit on handled exceptions
 });
 
+app.use(helmet());
 
 // parse application/x-www-form-urlencoded
 app.use(bodyParser.urlencoded({ extended: false }))

--- a/package-lock.json
+++ b/package-lock.json
@@ -1362,6 +1362,11 @@
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
     },
+    "helmet": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/helmet/-/helmet-4.1.0.tgz",
+      "integrity": "sha512-KWy75fYN8hOG2Rhl8e5B3WhOzb0by1boQum85TiddIE9iu6gV+TXbUjVC17wfej0o/ZUpqB9kxM0NFCZRMzf+Q=="
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "express": "^4.17.1",
     "express-healthcheck": "^0.1.0",
     "express-winston": "^4.0.5",
+    "helmet": "^4.1.0",
     "node-fetch": "^2.6.0",
     "node-stream-zip": "^1.11.3",
     "winston": "^3.3.3",


### PR DESCRIPTION
```
curl localhost:3000/healthcheck -v
* About to connect() to localhost port 3000 (#0)
*   Trying 127.0.0.1...
* Connected to localhost (127.0.0.1) port 3000 (#0)
> GET /healthcheck HTTP/1.1
> User-Agent: curl/7.29.0
> Host: localhost:3000
> Accept: */*
>
< HTTP/1.1 500 Internal Server Error
< Content-Security-Policy: default-src 'self';base-uri 'self';block-all-mixed-content;font-src 'self' https: data:;frame-ancestors 'self';img-src 'self' data:;object-src 'none';script-src 'self';script-src-attr 'none';style-src 'self' https: 'unsafe-inline';upgrade-insecure-requests
< X-DNS-Prefetch-Control: off
< Expect-CT: max-age=0
< X-Frame-Options: SAMEORIGIN
< Strict-Transport-Security: max-age=15552000; includeSubDomains
< X-Download-Options: noopen
< X-Content-Type-Options: nosniff
< X-Permitted-Cross-Domain-Policies: none
< Referrer-Policy: no-referrer
< X-XSS-Protection: 0
< Content-Type: application/json; charset=utf-8
< Content-Length: 16
< ETag: W/"10-JAHyqt677vsRiUuH5EcwcQkjxIs"
< Date: Sun, 06 Sep 2020 19:45:52 GMT
< Connection: keep-alive
<
* Connection #0 to host localhost left intact
```