### PR TITLE
Tolerate changelist.format=%d.v%s

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -68,6 +68,6 @@ module.exports = {
    */
   getArchiveUrl: (build_url, hash) => {
     let shortHash = hash.substring(0, 12);
-    return build_url + 'artifact/**/*' + shortHash + '/*' + shortHash + '*/*zip*/archive.zip';
+    return build_url + 'artifact/**/*' + shortHash + '*/*' + shortHash + '*/*zip*/archive.zip';
   }
 };

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -68,6 +68,6 @@ module.exports = {
    */
   getArchiveUrl: (build_url, hash) => {
     let shortHash = hash.substring(0, 12);
-    return build_url + 'artifact/**/*.' + shortHash + '/*.' + shortHash + '*/*zip*/archive.zip';
+    return build_url + 'artifact/**/*' + shortHash + '/*' + shortHash + '*/*zip*/archive.zip';
   }
 };


### PR DESCRIPTION
Noticed in https://github.com/jenkinsci/jenkins-test-harness/pull/277 that incremental deployment was not working, due to https://github.com/jenkinsci/incrementals-tools/pull/19 breaking the assumption about the final version format. Amends #10 which was introduced for the previously recommended JEP-229 format.