### PR TITLE
Handle `a_` and `b_` in incremental version numbers

### DIFF
--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -67,7 +67,9 @@ module.exports = {
    * build tooling (consult JEP-305)
    */
   getArchiveUrl: (build_url, hash) => {
-    let shortHash = hash.substring(0, 12).replace(/[ab]/g, '$&*');
-    return build_url + 'artifact/**/*' + shortHash + '*/*' + shortHash + '*/*zip*/archive.zip';
+    let shortHash = hash.substring(0, 12);
+    // https://github.com/jenkinsci/incrementals-tools/pull/24
+    let versionPattern = shortHash.replace(/[ab]/g, '$&*');
+    return build_url + 'artifact/**/*' + versionPattern + '*/*' + versionPattern + '*/*zip*/archive.zip';
   }
 };

--- a/lib/pipeline.js
+++ b/lib/pipeline.js
@@ -67,7 +67,7 @@ module.exports = {
    * build tooling (consult JEP-305)
    */
   getArchiveUrl: (build_url, hash) => {
-    let shortHash = hash.substring(0, 12);
+    let shortHash = hash.substring(0, 12).replace(/[ab]/g, '$&*');
     return build_url + 'artifact/**/*' + shortHash + '*/*' + shortHash + '*/*zip*/archive.zip';
   }
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "incrementals-publisher",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "incrementals-publisher",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "",
   "private": true,
   "main": "index.js",

--- a/test/pipeline-test.js
+++ b/test/pipeline-test.js
@@ -1,3 +1,4 @@
+/* eslint-disable mocha/no-mocha-arrows */
 const assert   = require('assert');
 const pipeline = require('../lib/pipeline.js');
 
@@ -156,6 +157,7 @@ describe('The Pipeline helpers', () => {
       const url = pipeline.getArchiveUrl(build_url, hash);
       assert.ok(url);
       assert.ok(url.match('archive.zip$'));
+      assert.ok(url.includes('a*cb*d4'), url); // https://github.com/jenkins-infra/jenkins.io/issues/4783
     });
   });
 

--- a/test/pipeline-test.js
+++ b/test/pipeline-test.js
@@ -154,9 +154,7 @@ describe('The Pipeline helpers', () => {
     it('should generate an archive.zip URL', () => {
       let hash = 'acbd4';
       const url = pipeline.getArchiveUrl(build_url, hash);
-      assert.ok(url);
-      assert.ok(url.match('archive.zip$'));
-      assert.ok(url.includes('a*cb*d4'), url); // https://github.com/jenkins-infra/jenkins.io/issues/4783
+      assert.strictEqual(url, 'https://ci.jenkins.io/job/structs-plugin/job/PR-36/3/artifact/**/*a*cb*d4*/*a*cb*d4*/*zip*/archive.zip');
     });
   });
 

--- a/test/pipeline-test.js
+++ b/test/pipeline-test.js
@@ -1,4 +1,3 @@
-/* eslint-disable mocha/no-mocha-arrows */
 const assert   = require('assert');
 const pipeline = require('../lib/pipeline.js');
 


### PR DESCRIPTION
I hope this will allow compatibility with https://github.com/jenkinsci/incrementals-tools/pull/24. Not sure how to test it in advance.
