### PR TITLE
Chore: Bump NodeJS from 16 to 18 (latest LTS)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,3 +96,4 @@ typings/
 xunit.xml
 
 github-app.pem
+.config

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16
+FROM node:18
 
 ENV NODE_ENV production
 ENV PORT 3000

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,10 +16,10 @@ if (JENKINS_URL.contains('ci.jenkins.io')) {
           checkout scm
         }
         stage('NPM Install') {
-          runDockerCommand('node:16',  'npm ci')
+          runDockerCommand('node:18',  'npm ci')
         }
         stage('Lint and Test') {
-          runDockerCommand('node:16',  'npm run test')
+          runDockerCommand('node:18',  'npm run test')
         }
       }
     }


### PR DESCRIPTION
NodeJS 18 is the current LTS for NodeJS