### PR TITLE
chore(GitHub Actions) refresh release-drafter and dependabot setups

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,6 +1,0 @@
-version: 1
-
-update_configs:
-  - package_manager: "javascript"
-    directory: "/"
-    update_schedule: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    labels:
+    - chore
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+    - dependencies
+  - package-ecosystem: docker
+    directory: "/"
+    schedule:
+      interval: weekly
+    labels:
+    - dependencies

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,5 @@
 # See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
 _extends: jenkinsci/.github
-# Semantic versioning: https://semver.org/
-version-template: $MAJOR.$MINOR.$PATCH
-tag-template: v$NEXT_MINOR_VERSION
-name-template: v$NEXT_MINOR_VERSION
+# Required for https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildDockerAndPublishImage.groovy
+name-template: 'next'
+tag-template: 'next'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,14 +1,16 @@
 name: Release Drafter
 on:
+  workflow_dispatch:
   push:
-    # branches to consider in the event; optional, defaults to all
-    branches:
-      - master
+  release:
+    types: [released]
+# Only allow 1 release-drafter build at a time to avoid creating multiple "next" releases
+concurrency: "release-drafter"
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@65c5fb495d1e69aa8c08a3317bc44ff8aabe9772 # v5
+      - uses: release-drafter/release-drafter@569eb7ee3a85817ab916c8f8ff03a5bd96c9c83e # v5
         env:
+          # This token is generated automatically by default in GitHub Actions: no need to create it manually
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- Some part of dependabot was disabled because using v1. Let's use all in v2!
- Added the tracking of the Dockerfile (to avoid manual updates of nodejs such as #27)
- Update release-drafter setup to map to other Jenkins Infra's Docker images (to enable CD with auto release notes)