### PR TITLE
Remove branch conditions on the 'Release' stage of the Jenkinfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -67,14 +67,8 @@ pipeline {
 
     stage('Release') {
       when {
-        allOf {
-          anyOf {
-            branch "main"
-            branch "beta"
-          }
-          // Only deploy to production from infra.ci.jenkins.io
-          expression { infra.isInfra() }
-        }
+        // Only deploy to production from infra.ci.jenkins.io
+        expression { infra.isInfra() }
       }
       steps {
         buildDockerAndPublishImage('incrementals-publisher', [automaticSemanticVersioning: true])


### PR DESCRIPTION
Follow-up of https://github.com/jenkins-infra/incrementals-publisher/pull/46#discussion_r1253576072

> No need for the branch check : https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildDockerAndPublishImage.groovy holds the conditional logic to publish only on the main branch (or on a tag).
> 
> Removing the branch condition also enable the hadolint/docker build in prs (instead of waiting for a release to realize the dockerfile is broken 😅)

