### PR TITLE
fixup: correct details markdown for dependency metadata

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -39,7 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const metadata = `<pre>&#xA;<dependency>&#xA;  <groupId>${entries[0].groupId}</groupId>&#xA;  <artifactId>${entries[0].artifactId}</artifactId>&#xA;  <version>${entries[0].version}</version>&#xA;</dependency>&#xA;</pre>`
+    const metadata = `<pre>&#xA;&#60;dependency>&#xA;  &#60;groupId>${entries[0].groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entries[0].artifactId}&#60;/artifactId>&#xA;  &#60;version>${entries[0].version}&#60;/version>&#xA;&#60;/dependency>&#xA;</pre>`
 
     return github.rest.checks.create({
       owner,

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,15 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    let summary = entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
-
-    summary += "```xml\n"
-    summary += "<dependency>\n"
-    summary += `  <groupId>${entries[0].groupId}</groupId>` + "\n"
-    summary += `  <artifactId>${entries[0].artifactId}</artifactId>` + "\n"
-    summary += `  <version>${entries[0].version}</version>` + "\n"
-    summary += "</dependency>\n"
-    summary += "```\n"
+    const metadata = `<pre>&#xA;<dependency>&#xA;  <groupId>${entries[0].groupId}</groupId>&#xA;  <artifactId>${entries[0].artifactId}</artifactId>&#xA;  <version>${entries[0].version}</version>&#xA;</dependency>&#xA;`
 
     return github.rest.checks.create({
       owner,
@@ -59,7 +51,8 @@ export default {
       details_url: entries[0].url,
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
-        summary: summary
+        summary: entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n"),
+        text: metadata
       }
     });
   }

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,7 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const metadata = `<pre>&#xA;<dependency>&#xA;  <groupId>${entries[0].groupId}</groupId>&#xA;  <artifactId>${entries[0].artifactId}</artifactId>&#xA;  <version>${entries[0].version}</version>&#xA;</dependency>&#xA;`
+    const metadata = `<pre>&#xA;<dependency>&#xA;  <groupId>${entries[0].groupId}</groupId>&#xA;  <artifactId>${entries[0].artifactId}</artifactId>&#xA;  <version>${entries[0].version}</version>&#xA;</dependency>&#xA;</pre>`
 
     return github.rest.checks.create({
       owner,


### PR DESCRIPTION
This PR sets the `text` value of the check run, using `<pre>`, `&#xA;` (new line) and `&#60;` (`<`) to avoid markdown rendering issue from #83: https://github.com/jenkinsci/jenkins-infra-test-plugin/pull/114/checks?check_run_id=21437296074

Before:
<img width="888" alt="image" src="https://github.com/jenkins-infra/incrementals-publisher/assets/91831478/96a74487-1c0a-498e-a2a5-2217a45d60bd">

After:
```
<pre>&#xA;&#60;dependency>&#xA;  &#60;groupId>${entries[0].groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entries[0].artifactId}&#60;/artifactId>&#xA;  &#60;version>${entries[0].version}&#60;/version>&#xA;&#60;/dependency>&#xA;</pre>
```
<pre>&#xA;&#60;dependency>&#xA;  &#60;groupId>${entries[0].groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entries[0].artifactId}&#60;/artifactId>&#xA;  &#60;version>${entries[0].version}&#60;/version>&#xA;&#60;/dependency>&#xA;</pre>


Fixup of:
- #83 

Ref:
- #22
- https://docs.github.com/en/rest/checks/runs?apiVersion=2022-11-28