### PR TITLE
chore: add missing quote in the JSON example of README.adoc

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -70,7 +70,7 @@ publishing incrementally built artifacts into Artifactory.
 [source,json]
 ----
 {
-  "build_url" : "https://ci.jenkins.io/job/structs-plugin/job/PR-36/3/
+  "build_url" : "https://ci.jenkins.io/job/structs-plugin/job/PR-36/3/"
 }
 ----
 


### PR DESCRIPTION
<img width="665" alt="image" src="https://github.com/jenkins-infra/incrementals-publisher/assets/91831478/debba7b7-718c-4b35-8177-f51b433e517f">
