### PR TITLE
chore: output dependency metadata for all artifacts in check run

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -39,7 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const metadata = `<pre>&#xA;&#60;dependency>&#xA;  &#60;groupId>${entries[0].groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entries[0].artifactId}&#60;/artifactId>&#xA;  &#60;version>${entries[0].version}&#60;/version>&#xA;&#60;/dependency>&#xA;</pre>`
+    const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 
     return github.rest.checks.create({
       owner,
@@ -52,7 +52,7 @@ export default {
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
         summary: entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n"),
-        text: metadata
+        text: `<pre>&#xA;${metadata}&#xA;</pre>`
       }
     });
   }


### PR DESCRIPTION
This PR outputs dependency metadata for all artifacts, not just the first one.

Ref:
- https://github.com/jenkins-infra/incrementals-publisher/issues/22#issuecomment-1937259098