### PR TITLE
feat: add plugin manager input syntax to check run summary

### DIFF
--- a/IncrementalsPlugin.js
+++ b/IncrementalsPlugin.js
@@ -240,9 +240,10 @@ class IncrementalsPlugin {
     const entriesForDisplay = entries.map(entry => {
       return {
         artifactId: entry.artifactId,
-        url: config.INCREMENTAL_URL + entry.path.replace(/[^/]+$/, ""),
-        version: entry.path.split("/").slice(-2)[0],
-        groupId: entry.path.split("/").slice(0, 3).join(".")
+        groupId: entry.groupId,
+        version: entry.version,
+        hpi: (entry.packaging == "hpi" ? `<code>${entry.artifactId}:incrementals;${entry.groupId};${entry.version}</code>` : ""),
+        url: config.INCREMENTAL_URL + entry.path.replace(/[^/]+$/, "")
       };
     })
 

--- a/IncrementalsPlugin.js
+++ b/IncrementalsPlugin.js
@@ -242,7 +242,7 @@ class IncrementalsPlugin {
         artifactId: entry.artifactId,
         groupId: entry.groupId,
         version: entry.version,
-        hpi: (entry.packaging == "hpi" ? `<code>${entry.artifactId}:incrementals;${entry.groupId};${entry.version}</code>` : ""),
+        hpi: (entry.packaging == "hpi" ? `${entry.artifactId}:incrementals;${entry.groupId};${entry.version}&#xA;` : ""),
         url: config.INCREMENTAL_URL + entry.path.replace(/[^/]+$/, "")
       };
     })

--- a/lib/github.js
+++ b/lib/github.js
@@ -41,7 +41,7 @@ export default {
 
     const rows = entries.map(entry => `|[${entry.artifactId}](${entry.url})|<code>${entry.artifactId}:incrementals;${entry.groupId};${entry.version}</code>|`).join("\n")
 
-    const table = "|Incrementals download links|[Plugin Installation Manager input format](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)|\n|--|--|\n" + rows
+    const table = "|Download links|[Plugin Installation Manager input format](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)|\n|--|--|\n" + rows
 
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,7 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const links = "### Download link(s):" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
+    const links = `### Download link${entries.length > 1 ? 's' : ''}:` + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
     const inputFormat = "### Plugin Installation Manager input format:\n```" + entries.map(entry => entry.hpi).join("") + "```\n([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))"
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,7 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const rows = entries.map(entry => `|[${entry.artifactId}](${entry.url})|<code>${entry.artifactId}:incrementals;${entry.groupId};${entry.version}</code>|`).join("\n")
+    const rows = entries.map(entry => `|[${entry.artifactId}](${entry.url})|${entry.hpi}|`).join("\n")
 
     const table = "|Download link(s)|[Plugin Installation Manager input format](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)|\n|--|--|\n" + rows
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,12 +39,9 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const downloadLinks = entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
-    const pluginManager = entries.map(entry => `${entry.artifactId}:incrementals;${entry.groupId};${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
+    const rows = entries.map(entry => `|[${entry.artifactId}](${entry.url})|<code>${entry.artifactId}:incrementals;${entry.groupId};${entry.version}</code>|`).join("\n")
 
-    let completeSummary = "### Incrementals download links:\n" + downloadLinks
-    completeSummary += "\n### Plugin Installation Manager input format:\nSee [documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)\n"
-    completeSummary += `<pre>${pluginManager}</pre>`
+    const table = "|Incrementals download links|[Plugin Installation Manager input format](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)|\n|--|--|\n" + rows
 
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 
@@ -58,7 +55,7 @@ export default {
       details_url: entries[0].url,
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
-        summary: completeSummary,
+        summary: table,
         text: `<pre>&#xA;${metadata}&#xA;</pre>`
       }
     });

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,7 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const links = `### Download link${entries.length > 1 ? 's' : ''}:` + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
+    const links = `### Download link${entries.length > 1 ? 's' : ''}:` + "\n" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
     const inputFormat = "### Plugin Installation Manager input format:\n```" + entries.map(entry => entry.hpi).join("") + "```\n([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))"
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -41,7 +41,7 @@ export default {
 
     const rows = entries.map(entry => `|[${entry.artifactId}](${entry.url})|${entry.hpi}|`).join("\n")
 
-    const table = "|Download link(s)|[Plugin Installation Manager input format](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)|\n|--|--|\n" + rows
+    const table = "|Download link(s)|Plugin Installation Manager input format (See [doc](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format), only for plugin)|\n|--|--|\n" + rows
 
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,9 +39,9 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const rows = entries.map(entry => `|[${entry.artifactId}](${entry.url})|${entry.hpi}|`).join("\n")
-
-    const table = "|Download link(s)|Plugin Installation Manager input format (See [doc](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format), only for plugin)|\n|--|--|\n" + rows
+    const links = entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
+    const inputFormat = entries.map(entry => entry.hpi).join("")
+    const summary = links + "Plugin Installation Manager input format (See [doc](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))\n" + `<pre>${inputFormat}</pre>`
 
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 
@@ -55,7 +55,7 @@ export default {
       details_url: entries[0].url,
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
-        summary: table,
+        summary: summary,
         text: `<pre>&#xA;${metadata}&#xA;</pre>`
       }
     });

--- a/lib/github.js
+++ b/lib/github.js
@@ -40,7 +40,7 @@ export default {
     const github = await getRestClient();
 
     const links = "### Download link(s):" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
-    const inputFormat = "### Plugin Installation Manager input format:\n<pre>" + entries.map(entry => entry.hpi).join("") + "</pre>\n([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))"
+    const inputFormat = "### Plugin Installation Manager input format:\n```" + entries.map(entry => entry.hpi).join("") + "```\n([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))"
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 
     return github.rest.checks.create({

--- a/lib/github.js
+++ b/lib/github.js
@@ -41,7 +41,7 @@ export default {
 
     const rows = entries.map(entry => `|[${entry.artifactId}](${entry.url})|<code>${entry.artifactId}:incrementals;${entry.groupId};${entry.version}</code>|`).join("\n")
 
-    const table = "|Download links|[Plugin Installation Manager input format](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)|\n|--|--|\n" + rows
+    const table = "|Download link(s)|[Plugin Installation Manager input format](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)|\n|--|--|\n" + rows
 
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,10 +39,8 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const links = entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
-    const inputFormat = entries.map(entry => entry.hpi).join("")
-    const summary = links + "Plugin Installation Manager input format (See [doc](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))\n" + `<pre>${inputFormat}</pre>`
-
+    const links = "### Download link(s):" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
+    const inputFormat = "### Plugin Installation Manager input format:\n<pre>" + entries.map(entry => entry.hpi).join("") + "</pre>\n([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))"
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 
     return github.rest.checks.create({
@@ -55,7 +53,7 @@ export default {
       details_url: entries[0].url,
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
-        summary: summary,
+        summary: links + inputFormat,
         text: `<pre>&#xA;${metadata}&#xA;</pre>`
       }
     });

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,7 +39,7 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const links = `### Download link${entries.length > 1 ? 's' : ''}:` + "\n" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
+    const links = `### Download link${entries.length > 1 ? "s" : ""}:` + "\n" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
     const inputFormat = "### Plugin Installation Manager input format:\n```" + entries.map(entry => entry.hpi).join("") + "```\n([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))"
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -39,6 +39,13 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
+    const downloadLinks = entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
+    const pluginManager = entries.map(entry => `${entry.artifactId}:incrementals;${entry.groupId};${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
+
+    let completeSummary = "### Incrementals download links:\n" + downloadLinks
+    completeSummary += "\n### Plugin Installation Manager input format:\nSee [documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format)\n"
+    completeSummary += `<pre>${pluginManager}</pre>`
+
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 
     return github.rest.checks.create({
@@ -51,7 +58,7 @@ export default {
       details_url: entries[0].url,
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
-        summary: entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n"),
+        summary: completeSummary,
         text: `<pre>&#xA;${metadata}&#xA;</pre>`
       }
     });

--- a/lib/permissions.js
+++ b/lib/permissions.js
@@ -57,8 +57,12 @@ export default {
             const groupId = result.project.groupId[0];
             const artifactId = result.project.artifactId[0];
             const version = result.project.version[0];
+            const packaging = result.project.packaging ? result.project.packaging[0] : ""
             entries.push({
               artifactId,
+              groupId,
+              version,
+              packaging,
               path: entry.name
             });
             log.info(util.format("Parsed %s with url=%s tag=%s GAV=%s:%s:%s", entry.name, url, tag, groupId, artifactId, version));


### PR DESCRIPTION
This PR adds plugin manager input syntax to check run summary for all artifacts packaged as "hpi", with a link to the corresponding doc.

Ref:
- #86 

How it looks, example with https://github.com/jenkinsci/jenkins/pull/8827/checks?check_run_id=21444277856
(Note: `cli` is not packaged as hpi, here just for illustration)

<details><summary>Before:</summary>

<h2>Deployed version 2.445-rc34655.9d9e2a_b_46731 to Incrementals</h2>

- [jenkins-core](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-core/2.445-rc34655.9d9e2a_b_46731/)
- [jenkins-war](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-war/2.445-rc34655.9d9e2a_b_46731/)
- [jenkins-parent](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-parent/2.445-rc34655.9d9e2a_b_46731/)
- [cli](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/cli/2.445-rc34655.9d9e2a_b_46731/)
- [jenkins-bom](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-bom/2.445-rc34655.9d9e2a_b_46731/)
- [websocket-spi](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/websocket-spi/2.445-rc34655.9d9e2a_b_46731/)
- [websocket-jetty10](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/websocket-jetty10/2.445-rc34655.9d9e2a_b_46731/)

</details>

<details><summary>After:</summary>

<h2>Deployed version 2.445-rc34655.9d9e2a_b_46731 to Incrementals</h2>

### Download link(s):
- [jenkins-core](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-core/2.445-rc34655.9d9e2a_b_46731/)
- [jenkins-war](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-war/2.445-rc34655.9d9e2a_b_46731/)
- [jenkins-parent](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-parent/2.445-rc34655.9d9e2a_b_46731/)
- [cli](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/cli/2.445-rc34655.9d9e2a_b_46731/)
- [jenkins-bom](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/jenkins-bom/2.445-rc34655.9d9e2a_b_46731/)
- [websocket-spi](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/websocket-spi/2.445-rc34655.9d9e2a_b_46731/)
- [websocket-jetty10](https://repo.jenkins-ci.org/incrementals/org/jenkins-ci/main/websocket-jetty10/2.445-rc34655.9d9e2a_b_46731/)
### Plugin Installation Manager input format:
```
cli:incrementals;org.jenkins-ci.main;2.445-rc34655.9d9e2a_b_46731
```
([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))

</details>
