### PR TITLE
chore: enable eslint results record even on failure

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -46,7 +46,9 @@ pipeline {
       }
       post {
         always {
-          recordIssues(tools: [
+          recordIssues(
+            enabledForFailure: true,
+            tools: [
               esLint(pattern: 'eslint-results.json'),
           ])
         }


### PR DESCRIPTION
This PR enable eslint results records even on failure, so we can check the actual errors instead of just a line of log like "script returned exit code 1" followed by "[ESLint] Skipping execution of recorder since overall result is 'FAILURE'".

Ex: https://ci.jenkins.io/job/Infra/job/incrementals-publisher/job/PR-88/10/pipeline-console/?selected-node=35