### PR TITLE
fixup: correct markdown for check run summary

### DIFF
--- a/lib/github.js
+++ b/lib/github.js
@@ -39,8 +39,8 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const links = `### Download link${entries.length > 1 ? "s" : ""}:` + "\n" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
-    const inputFormat = "### Plugin Installation Manager input format:\n```" + entries.map(entry => entry.hpi).join("") + "```\n([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))"
+    const links = `#### Download link${entries.length > 1 ? "s" : ""}:` + "\n" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
+    const inputFormat = "#### Plugin Installation Manager input format: ([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))\n<pre>" + entries.map(entry => entry.hpi).join("") + "</pre>"
     const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
 
     return github.rest.checks.create({
@@ -53,7 +53,7 @@ export default {
       details_url: entries[0].url,
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
-        summary: links + inputFormat,
+        summary: links + "\n\n" + inputFormat,
         text: `<pre>&#xA;${metadata}&#xA;</pre>`
       }
     });


### PR DESCRIPTION
This PR fixes and improves the markdown from #88 by:
- Adding new lines
- Replacing the fenced code block by a `<pre>` block (as no copy button was displayed on the check run page)
- Decreasing titles size
- Moving the documentation link in the title

<details><summary>Before:</summary>

<img width="612" alt="image" src="https://github.com/jenkins-infra/incrementals-publisher/assets/91831478/26486f3f-b966-43cc-a343-2311c61261ea">

</details>

<details><summary>After:</summary>

<img width="576" alt="image" src="https://github.com/jenkins-infra/incrementals-publisher/assets/91831478/166654b3-c10b-4cd9-b0bb-b59c9ca7b57f">

</details>

Fixup of:
- #88

Ref:
- #86