### PR TITLE
chore: build docker image on ci.jenkins.io too

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,12 +68,8 @@ pipeline {
     }
 
     stage('Release') {
-      when {
-        // Only deploy to production from infra.ci.jenkins.io
-        expression { infra.isInfra() }
-      }
       steps {
-        buildDockerAndPublishImage('incrementals-publisher', [automaticSemanticVersioning: true, targetplatforms: 'linux/amd64,linux/arm64'])
+        buildDockerAndPublishImage('incrementals-publisher', [automaticSemanticVersioning: true, targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra()])
       }
     }
   }


### PR DESCRIPTION
This PR allows to build the docker image without publication on ci.jenkins.io too, and simplifies a bit the pipeline thanks to https://github.com/jenkins-infra/pipeline-library/pull/784