### PR TITLE
chore: input format in check summary only if there a plugin

### DIFF
--- a/IncrementalsPlugin.js
+++ b/IncrementalsPlugin.js
@@ -242,7 +242,7 @@ class IncrementalsPlugin {
         artifactId: entry.artifactId,
         groupId: entry.groupId,
         version: entry.version,
-        hpi: (entry.packaging == "hpi" ? `${entry.artifactId}:incrementals;${entry.groupId};${entry.version}&#xA;` : ""),
+        packaging: entry.packaging,
         url: config.INCREMENTAL_URL + entry.path.replace(/[^/]+$/, "")
       };
     })

--- a/lib/github.js
+++ b/lib/github.js
@@ -30,6 +30,7 @@ function summary(entries) {
     .filter(entry => entry.packaging == "hpi")
     .map(entry => `${entry.artifactId}:incrementals;${entry.groupId};${entry.version}`)
 
+  // Output the input format section only if there is a plugin, not usable with other type of artifact
   return hpi.length == 0 ? links : `${links}\n\n#### Plugin Installation Manager input format: ([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))\n<pre>${hpi.join("\n")}</pre>`
 }
 

--- a/lib/github.js
+++ b/lib/github.js
@@ -23,6 +23,24 @@ async function getRestClient() {
   })
 }
 
+function summary(entries) {
+  const links = `#### Download link${entries.length > 1 ? "s" : ""}:\n${entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")}`
+
+  const hpi = entries
+    .filter(entry => entry.packaging == "hpi")
+    .map(entry => `${entry.artifactId}:incrementals;${entry.groupId};${entry.version}`)
+
+  return hpi.length == 0 ? links : `${links}\n\n#### Plugin Installation Manager input format: ([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))\n<pre>${hpi.join("\n")}</pre>`
+}
+
+function text(entries) {
+  const metadata = entries
+    .map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`)
+    .join("&#xA;")
+
+  return `<pre>${metadata}</pre>`
+}
+
 export default {
   commitExists: async (owner, repo, ref) => {
     const github = await getRestClient();
@@ -39,10 +57,6 @@ export default {
   createStatus: async (owner, repo, head_sha, entries) => {
     const github = await getRestClient();
 
-    const links = `#### Download link${entries.length > 1 ? "s" : ""}:` + "\n" + entries.map(entry => `- [${entry.artifactId}](${entry.url})`).join("\n")
-    const inputFormat = "#### Plugin Installation Manager input format: ([documentation](https://github.com/jenkinsci/plugin-installation-manager-tool/#plugin-input-format))\n<pre>" + entries.map(entry => entry.hpi).join("") + "</pre>"
-    const metadata = entries.map(entry => `&#60;dependency>&#xA;  &#60;groupId>${entry.groupId}&#60;/groupId>&#xA;  &#60;artifactId>${entry.artifactId}&#60;/artifactId>&#xA;  &#60;version>${entry.version}&#60;/version>&#xA;&#60;/dependency>`).join("&#xA;")
-
     return github.rest.checks.create({
       owner,
       repo,
@@ -53,8 +67,8 @@ export default {
       details_url: entries[0].url,
       output: {
         title: `Deployed version ${entries[0].version} to Incrementals`,
-        summary: links + "\n\n" + inputFormat,
-        text: `<pre>&#xA;${metadata}&#xA;</pre>`
+        summary: summary(entries),
+        text: text(entries)
       }
     });
   }


### PR DESCRIPTION
This PR outputs the plugin installation manager input format section in check summary only if there is a plugin (packaging "hpi").
There is no change to the formatting.

Follow-up of:
- https://github.com/jenkins-infra/incrementals-publisher/pull/88#discussion_r1485815862

Ref:
- #86 