### PR TITLE
chore(Jenkinsfile): Remove automaticSemanticVersioning from script call

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
 
     stage('Release') {
       steps {
-        buildDockerAndPublishImage('incrementals-publisher', [automaticSemanticVersioning: true, targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra()])
+        buildDockerAndPublishImage('incrementals-publisher', [targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra()])
       }
     }
   }


### PR DESCRIPTION
As per - https://github.com/jenkins-infra/helpdesk/issues/2778

`automaticSemanticVersioning` is set to true by default, we no longer need to set the parameter in the script call.