### PR TITLE
Use SARIF format for typos check in CI

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -19,11 +19,11 @@ pipeline {
   stages {
     stage('Check for typos') {
       steps {
-        sh '''typos --format json | typos-checkstyle - > checkstyle.xml || true'''
+        sh '''typos --format sarif > typos.sarif || true'''
       }
       post {
         always {
-          recordIssues(tools: [checkStyle(id: 'typos', name: 'Typos', pattern: 'checkstyle.xml')])
+          recordIssues(tools: [sarif(id: 'typos', name: 'Typos', pattern: 'typos.sarif')])
         }
       }
     }


### PR DESCRIPTION
The SARIF format is now supported out of the box, so conversion to Checkstyle XML is no longer needed.