### PR TITLE
chore(Jenkinsfile) switch to private registry and only build for `arm64`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,11 @@ pipeline {
 
     stage('Release') {
       steps {
-        buildDockerAndPublishImage('incrementals-publisher', [targetplatforms: 'linux/amd64,linux/arm64', disablePublication: !infra.isInfra()])
+        buildDockerAndPublishImage('incrementals-publisher', [
+          publishToPrivateAzureRegistry: true,
+          targetplatforms: 'linux/arm64', 
+          disablePublication: !infra.isInfra(),
+        ])
       }
     }
   }


### PR DESCRIPTION
- Use private registry: jenkins-infra/helpdesk#4769
- No need to build for `amd64` nowadays (less data to pull/push and less agents to use)


Note: this change is also here to ensure that the Docker image is build properly on both ci.jenkins.io (was already the case before) and also on infra.ci.jenkins.io (haven't released it since quite some times)