### PR TITLE
Use release drafter v7.0.0

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,5 +1,5 @@
-# See https://github.com/jenkinsci/.github/blob/master/.github/release-drafter.adoc
-_extends: jenkinsci/.github
+# https://github.com/jenkins-infra/.github/blob/master/.github/release-drafter.yml
+_extends: github:jenkins-infra/.github:/.github/release-drafter.yml
 # Required for https://github.com/jenkins-infra/pipeline-library/blob/master/vars/buildDockerAndPublishImage.groovy
 name-template: 'next'
 tag-template: 'next'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,6 +2,8 @@ name: Release Drafter
 on:
   workflow_dispatch:
   push:
+    branches:
+      - main
   release:
     types: [released]
 # Only allow 1 release-drafter build at a time to avoid creating multiple "next" releases

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -10,7 +10,7 @@ jobs:
   update_release_draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@3f0f87098bd6b5c5b9a36d49c41d998ea58f9348 # v6
+      - uses: release-drafter/release-drafter@3a7fb5c85b80b1dda66e1ccb94009adbbd32fce3 # v7.0.0
         env:
           # This token is generated automatically by default in GitHub Actions: no need to create it manually
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Use release drafter v7.0.0

Use release drafter v7.0.0 and explicitly load release drafter base config from GitHub

The [release drafter documentation](https://github.com/release-drafter/release-drafter/blob/master/docs/configuration-loading.md#fetching-from-a-repo-named-github) says

> The github: prefix is used internally to recognize you want to explicitly fetch from a remote (using octokit) instead of loading a file on the runtime's filesystem.

Switches from the release-drafter configuration of the jenkinsci GitHub organization to the release-drafter configuration of the jenkins-infra GitHub organization for consistency with other jenkins-infra repositories.

Run release drafter on push to main, not push to all branches

Supersedes pull request:

* https://github.com/jenkins-infra/incrementals-publisher/pull/121
