### PR TITLE
chore(Dockerfile/Makefile): replace npm install with npm ci

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /usr/src/app
 # where available (npm@5+)
 COPY package*.json ./
 
-RUN npm install
+RUN npm ci
 
 # Bundle app source
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ run: ## run the docker hub
 
 .PHONY: test
 test: ## run tests outside of docker
-	[ -e node_modules ] || npm install 
+	[ -e node_modules ] || npm ci 
 	npm run test
 
 .PHONY: help


### PR DESCRIPTION
Ref:

- https://github.com/jenkins-infra/helpdesk/issues/5119

enforcing npm ci over npm install across CI/CD pipelines for reproducible builds.

- `Dockerfile`: `npm install` → `npm ci`
- `Makefile`: `npm install` → `npm ci` in the `test` target
