### PR TITLE
chore(renovate) ignore NodeJS as already tracked by `updatecli`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,5 +5,6 @@
     ":semanticCommitsDisabled",
     "schedule:monthly"
   ],
-  "rebaseWhen": "conflicted"
+  "rebaseWhen": "conflicted",
+  "ignoreDeps": ["node"]
 }


### PR DESCRIPTION
Ref. https://github.com/jenkins-infra/incrementals-publisher/pull/135#pullrequestreview-4845907907 and https://docs.renovatebot.com/configuration-options/#ignoredeps