### PR TITLE
chore(GHA) bump release-drafter to `7.6.0`

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Release Drafter
-        uses: release-drafter/release-drafter@139054aeaa9adc52ab36ddf67437541f039b88e2 # v7.1.1
+        uses: release-drafter/release-drafter@eada3c96a64734dd381cfbda23511034e328ddb0 # v7.6.0
         with:
           # This token is generated automatically by default in GitHub Actions: no need to create it manually
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Doing manually because Renovabot does not seem to take care of this change in its current configuration.